### PR TITLE
Refactor a bit and take some edge cases into account

### DIFF
--- a/components/evaltext.js
+++ b/components/evaltext.js
@@ -3,9 +3,8 @@ import {femaleList, maleList, neutralList} from './words';
 class EvalText extends React.Component {
   render() {
     const wordHighlight =
-      femaleList.includes(this.props.word.toLowerCase().replace(/[^A-Za-z0-9]/g, '')) ? "femaleWord" : 
-        maleList.includes(this.props.word.toLowerCase().replace(/[^A-Za-z0-9]/g, '')) ? "maleWord" :
-          neutralList.includes(this.props.word.toLowerCase().replace(/[^A-Za-z0-9]/g, '')) ? "neutralWord" : "neutralWord" 
+      femaleList.includes(this.props.word.toLowerCase().replace(/[\W].*/g, '')) ? "femaleWord" : 
+        maleList.includes(this.props.word.toLowerCase().replace(/[\W].*/g, '')) ? "maleWord" : "neutralWord"
 
     return (
     <div className="textBox">


### PR DESCRIPTION
Contains the following refactors:

- Refactored the regex
- The regex takes into account contracted words (like "he's", "she'll", "they're", etc.) (partially overlaps with #2)
- Took out the ternary that checks for neutral words because we aren't doing anything with them currently.